### PR TITLE
Add OpenAI integration

### DIFF
--- a/BlazorOllamaGlobal.Client/Program.cs
+++ b/BlazorOllamaGlobal.Client/Program.cs
@@ -12,6 +12,18 @@ builder.Services.AddScoped<OllamaService>(sp =>
     var httpClient = new HttpClient { BaseAddress = new Uri("http://localhost:11434") };
     return new OllamaService(httpClient);
 });
+builder.Services.AddScoped<OpenAIService>(sp =>
+{
+    var config = sp.GetRequiredService<IConfiguration>();
+    var apiKey = config["OpenAI:ApiKey"] ?? string.Empty;
+    var httpClient = new HttpClient { BaseAddress = new Uri("https://api.openai.com/") };
+    if (!string.IsNullOrEmpty(apiKey))
+    {
+        httpClient.DefaultRequestHeaders.Authorization =
+            new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", apiKey);
+    }
+    return new OpenAIService(httpClient);
+});
 builder.Services.AddScoped(sp => 
     new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
 builder.Services.AddScoped<ChatManagerService>();

--- a/BlazorOllamaGlobal.Client/Services/ChatManagerService.cs
+++ b/BlazorOllamaGlobal.Client/Services/ChatManagerService.cs
@@ -7,14 +7,16 @@ namespace BlazorOllamaGlobal.Client.Services;
 public class ChatManagerService
 {
     private readonly OllamaService ollamaService;
+    private readonly OpenAIService openAIService;
     private readonly ToolService toolService;
     private readonly TileService tileService;
 
-    public ChatManagerService(OllamaService ollamaService, ToolService toolService, TileService tileService)
+    public ChatManagerService(OllamaService ollamaService, ToolService toolService, TileService tileService, OpenAIService openAIService)
     {
         this.ollamaService = ollamaService;
         this.toolService = toolService;
         this.tileService = tileService;
+        this.openAIService = openAIService;
     }
 
     private Dictionary<string, List<ChatMessage>> ChatMessages { get; set; } = new();
@@ -81,7 +83,9 @@ public class ChatManagerService
                     x.IsExiting is not true).GetAsJSON()}" });
             }
             
-            var chatResponse = await ollamaService.ChatAsync(request);
+            var chatResponse = model.Contains("gpt")
+                ? await openAIService.ChatAsync(request)
+                : await ollamaService.ChatAsync(request);
 
             if (tileHasContent)
                 ChatMessages[chatID].RemoveAt(ChatMessages[chatID].Count - 1);

--- a/BlazorOllamaGlobal.Client/Services/OpenAIService.cs
+++ b/BlazorOllamaGlobal.Client/Services/OpenAIService.cs
@@ -1,0 +1,60 @@
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using BlazorOllamaGlobal.Client.Models.Chats;
+
+namespace BlazorOllamaGlobal.Client.Services;
+
+public class OpenAIService
+{
+    private readonly HttpClient _httpClient;
+
+    public OpenAIService(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+
+    public async Task<ChatResponse> ChatAsync(ChatRequest request)
+    {
+        request.Stream = false;
+        // Build OpenAI chat completion request
+        var payload = new JsonObject
+        {
+            ["model"] = request.Model,
+            ["messages"] = JsonSerializer.SerializeToNode(request.Messages),
+            ["stream"] = false
+        };
+        if (request.Tools != null && request.Tools.Any())
+        {
+            payload["tools"] = JsonSerializer.SerializeToNode(request.Tools);
+            payload["tool_choice"] = "auto";
+        }
+
+        var content = new StringContent(payload.ToJsonString(), Encoding.UTF8, "application/json");
+        var response = await _httpClient.PostAsync("v1/chat/completions", content);
+        response.EnsureSuccessStatusCode();
+        var rawJson = await response.Content.ReadAsStringAsync();
+
+        var doc = JsonNode.Parse(rawJson)!.AsObject();
+        var choice = doc["choices"]![0]!.AsObject();
+        var message = choice["message"]!.AsObject();
+
+        var chatResponse = new ChatResponse
+        {
+            Model = doc["model"]!.GetValue<string>(),
+            CreatedAt = DateTimeOffset.FromUnixTimeSeconds(doc["created"]!.GetValue<long>()).DateTime,
+            ResponseMessage = new ChatResponseMessage
+            {
+                Role = message["role"]!.GetValue<string>(),
+                Content = message["content"]?.GetValue<string>() ?? string.Empty,
+                ToolCalls = message["tool_calls"] != null
+                    ? message["tool_calls"]!.Deserialize<List<ToolCall>>()
+                    : null
+            },
+            Done = true,
+            DoneReason = choice["finish_reason"]?.GetValue<string>() ?? string.Empty
+        };
+        return chatResponse;
+    }
+}

--- a/BlazorOllamaGlobal.Client/wwwroot/appsettings.Development.json
+++ b/BlazorOllamaGlobal.Client/wwwroot/appsettings.Development.json
@@ -4,5 +4,8 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "OpenAI": {
+    "ApiKey": "YOUR_API_KEY_HERE"
   }
 }

--- a/BlazorOllamaGlobal.Client/wwwroot/appsettings.json
+++ b/BlazorOllamaGlobal.Client/wwwroot/appsettings.json
@@ -4,5 +4,8 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "OpenAI": {
+    "ApiKey": "YOUR_API_KEY_HERE"
   }
 }

--- a/BlazorOllamaGlobal/Program.cs
+++ b/BlazorOllamaGlobal/Program.cs
@@ -28,6 +28,18 @@ builder.Services.AddScoped<OllamaService>(sp =>
     var httpClient = new HttpClient { BaseAddress = new Uri("http://localhost:11434") };
     return new OllamaService(httpClient);
 });
+builder.Services.AddScoped<OpenAIService>(sp =>
+{
+    var config = sp.GetRequiredService<IConfiguration>();
+    var apiKey = config["OpenAI:ApiKey"] ?? string.Empty;
+    var httpClient = new HttpClient { BaseAddress = new Uri("https://api.openai.com/") };
+    if (!string.IsNullOrEmpty(apiKey))
+    {
+        httpClient.DefaultRequestHeaders.Authorization =
+            new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", apiKey);
+    }
+    return new OpenAIService(httpClient);
+});
 builder.Services.AddScoped<ChatManagerService>();
 builder.Services.AddScoped<ToolService>();
 builder.Services.AddSingleton<TileService>();

--- a/BlazorOllamaGlobal/appsettings.Development.json
+++ b/BlazorOllamaGlobal/appsettings.Development.json
@@ -8,5 +8,8 @@
   },
   "ConnectionStrings": {
     "MSSQLConnection": "Server=localhost;Database=BlazorOllama;User Id=sa;Password=****;"
+  },
+  "OpenAI": {
+    "ApiKey": "YOUR_API_KEY_HERE"
   }
 }

--- a/BlazorOllamaGlobal/appsettings.json
+++ b/BlazorOllamaGlobal/appsettings.json
@@ -5,5 +5,8 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "OpenAI": {
+    "ApiKey": "YOUR_API_KEY_HERE"
+  }
 }


### PR DESCRIPTION
## Summary
- add new OpenAIService to call OpenAI chat completions
- allow ChatManagerService to switch between Ollama and OpenAI
- register OpenAIService in client and server
- add OpenAI API key placeholders to config files

## Testing
- `dotnet build BlazorOllamaGlobal.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_686a9e38b6e48330a9596e621490b5fe